### PR TITLE
Fix foreach warning when ->queries is null.

### DIFF
--- a/debug-bar-query-count-alert.php
+++ b/debug-bar-query-count-alert.php
@@ -82,6 +82,10 @@ class Debug_Bar_Query_Count_Button {
 	public function get_stats() {
 		global $wpdb;
 
+		if ( ! $wpdb->queries ) {
+			return;
+		}
+
 		$this->query_time = 0;
 		foreach ( $wpdb->queries as $query ) {
 			$this->query_time += $query[1];


### PR DESCRIPTION
Hey Matt, saw this on my VIP local so thought I'd throw you a PR for fix.

<img width="1109" alt="screen shot 2017-08-16 at 10 59 28 am" src="https://user-images.githubusercontent.com/818980/29369970-1594e768-8272-11e7-8b92-de6df0b76e31.png">
